### PR TITLE
Fix python 3 incompatibility 

### DIFF
--- a/pytest_resilient_circuits/resilient_circuits_fixtures.py
+++ b/pytest_resilient_circuits/resilient_circuits_fixtures.py
@@ -15,10 +15,7 @@ from pytest_resilient_circuits.circuits_fixtures import manager, watcher
 import resilient
 from resilient import SimpleHTTPException
 import resilient_circuits.app
-try:
-    import StringIO
-except:
-    from io import StringIO
+from six import StringIO
 
 try:
     import ConfigParser as configparser
@@ -344,9 +341,9 @@ port = 443
             # build a config file using canned values for [resilient] and the integration we're testing
             #self.config_file.write(resilient_config_data)
             # use canned values
-            config_parser.readfp(StringIO.StringIO(resilient_config_data))
+            config_parser.read_file(StringIO(resilient_config_data))
             config_data = getattr(request.module, "config_data", "")
-            config_parser.readfp(StringIO.StringIO(config_data))
+            config_parser.read_file(StringIO(config_data))
 
         # add environment variables which override existing values
         host = os.environ.get("TEST_RESILIENT_APPLIANCE")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ requirements = [
     'pytest>=3.0.0',
     'resilient>={}.{}'.format(major, minor),
     'resilient-circuits>={}.{}'.format(major, minor),
-    'ConfigParser'
+    'ConfigParser',
+    'six',
 ]
 
 setup(


### PR DESCRIPTION
use six for cross-version-compatible usage of StringIO